### PR TITLE
WL21389: Preview of PR2

### DIFF
--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -155,6 +155,10 @@ void RenderableShapeEntityItem::computeShapeInfo(ShapeInfo& info) {
             }
         }
         break;
+        case entity::Shape::Circle:{
+            _collisionShapeType = SHAPE_TYPE_CIRCLE;
+        }
+        break;
         case entity::Shape::Cylinder: {
             _collisionShapeType = SHAPE_TYPE_CYLINDER_Y;
             // TODO WL21389: determine if rotation is axis-aligned
@@ -170,9 +174,6 @@ void RenderableShapeEntityItem::computeShapeInfo(ShapeInfo& info) {
         case entity::Shape::Triangle:
         case entity::Shape::Hexagon:
         case entity::Shape::Octagon:
-        case entity::Shape::Circle:  //TODO WL21389: Circles behaves a bit odd for collision
-                                     // landing toward the center sometimes results in the avatar 
-                                     // sliding to the side (byproduct of flat conical?)
         case entity::Shape::Cone:{
             ShapeInfo::PointList points;
             computeSimpleHullPointListForShape(this, points);
@@ -214,7 +215,7 @@ void RenderableShapeEntityItem::computeShapeInfo(ShapeInfo& info) {
     EntityItem::computeShapeInfo(info);
 }
 
-// This value specifes how the shape should be treated by physics calculations.
+// This value specifies how the shape should be treated by physics calculations.
 ShapeType RenderableShapeEntityItem::getShapeType() const {
     return _collisionShapeType;
 }

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -134,7 +134,13 @@ void RenderableShapeEntityItem::computeShapeInfo(ShapeInfo& info) {
     const glm::vec3 entityDimensions = getDimensions();
 
     switch (_shape){
-        case entity::Shape::Quad:
+        case entity::Shape::Quad: {
+            // Not in GeometryCache::buildShapes, unsupported.
+            _collisionShapeType = SHAPE_TYPE_ELLIPSOID;
+            //TODO WL21389: Add a SHAPE_TYPE_QUAD ShapeType and treat 
+            // as a special box (later if desired support)
+        }
+        break;
         case entity::Shape::Cube: {
             _collisionShapeType = SHAPE_TYPE_BOX;
         }

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -122,17 +122,56 @@ void RenderableShapeEntityItem::computeShapeInfo(ShapeInfo& info) {
 
         }
         break;
+        // gons, ones, & angles built via GeometryCache::extrudePolygon
         case entity::Shape::Triangle:
         case entity::Shape::Hexagon:
         case entity::Shape::Octagon:
         case entity::Shape::Circle:
+        case entity::Shape::Cone:{
+            //TODO WL21389: SHAPE_TYPE_SIMPLE_HULL and pointCollection (later)
+            _collisionShapeType = SHAPE_TYPE_ELLIPSOID;
+        }
+        break;
+        // hedrons built via GeometryCache::setUpFlatShapes
         case entity::Shape::Tetrahedron:
         case entity::Shape::Octahedron:
         case entity::Shape::Dodecahedron:
-        case entity::Shape::Icosahedron:
-        case entity::Shape::Cone: {
+        case entity::Shape::Icosahedron: {
             //TODO WL21389: SHAPE_TYPE_SIMPLE_HULL and pointCollection (later)
-            _collisionShapeType = SHAPE_TYPE_ELLIPSOID;
+            auto geometryCache = DependencyManager::get<GeometryCache>();
+            const GeometryCache::ShapeData * shapeData = geometryCache->getShapeData(MAPPING[_shape]);
+            if (!shapeData){
+                //--EARLY EXIT--( data isn't ready for some reason... )
+                break;
+            }
+            const gpu::BufferView & shapeVerts = shapeData->_positionView;
+            const gpu::BufferView & shapeNorms = shapeData->_normalView;
+            assert(shapeVerts._size == shapeNorms._size);
+            ShapeInfo::PointList points;
+            //const size_t numItems = shapeVerts._size - (shapeVerts._size / shapeVerts._stride);
+            //TODO WL21389:  The difference between getNum and getNumElements is that one returns a
+            //               BufferView::Index and the other BufferView::Size...?
+            const gpu::BufferView::Size numItems = shapeVerts.getNumElements();
+            const glm::vec3 halfExtents = entityDimensions * 0.5f;
+            debugDump();
+            qCDebug(entities) << "------------------ Begin Vert Info( ComputeShapeInfo ) -----------------------------";
+            qCDebug(entities) << " name:" << _name << ": has " << numItems << " vert info pairs.";
+            points.reserve( numItems );
+            for (gpu::BufferView::Index i = 0; i < (gpu::BufferView::Index)numItems; ++i) {
+                const geometry::Vec &curVert = shapeVerts.get<geometry::Vec>(i);
+                const geometry::Vec &curNorm = shapeNorms.get<geometry::Vec>(i);
+                qCDebug(entities) << "    --------------------";
+                qCDebug(entities) << "         Vert( " << i << " ): " << debugTreeVector(curVert);
+                qCDebug(entities) << "         Norm( " << i << " ): " << debugTreeVector(curNorm);
+                points.push_back(curNorm * halfExtents);
+                qCDebug(entities) << "         Point( " << i << " ): " << debugTreeVector( (curNorm * halfExtents) );
+            }
+            qCDebug(entities) << "-------------------- End Vert Info( ComputeShapeInfo ) -----------------------------";
+            ShapeInfo::PointCollection pointCollection;
+            pointCollection.push_back(points);
+            info.setPointCollection(pointCollection);
+
+            _collisionShapeType = SHAPE_TYPE_SIMPLE_HULL;
         }
         break;
         case entity::Shape::Torus:

--- a/libraries/physics/src/ShapeFactory.cpp
+++ b/libraries/physics/src/ShapeFactory.cpp
@@ -314,6 +314,7 @@ const btCollisionShape* ShapeFactory::createShapeFromInfo(const ShapeInfo& info)
             shape = new btCylinderShapeZ(btHalfExtents);
         }
         break;
+        case SHAPE_TYPE_CIRCLE:
         case SHAPE_TYPE_CYLINDER_Y: {
             const glm::vec3 halfExtents = info.getHalfExtents();
             const btVector3 btHalfExtents(halfExtents.x, halfExtents.y, halfExtents.z);

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -428,6 +428,14 @@ void GeometryCache::buildShapes() {
  
 }
 
+const GeometryCache::ShapeData * GeometryCache::getShapeData(const Shape shape) const {
+    if (((int)shape < 0) || ((int)shape >= _shapes.size())){
+        return NULL;
+    }
+
+    return &_shapes[shape];
+}
+
 gpu::Stream::FormatPointer& getSolidStreamFormat() {
     if (!SOLID_STREAM_FORMAT) {
         SOLID_STREAM_FORMAT = std::make_shared<gpu::Stream::Format>(); // 1 for everyone

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -430,7 +430,7 @@ void GeometryCache::buildShapes() {
 
 const GeometryCache::ShapeData * GeometryCache::getShapeData(const Shape shape) const {
     if (((int)shape < 0) || ((int)shape >= _shapes.size())){
-        return NULL;
+        return nullptr;
     }
 
     return &_shapes[shape];

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -335,15 +335,19 @@ public:
 
     using VShape = std::array<ShapeData, NUM_SHAPES>;
 
-    VShape _shapes;
+    const ShapeData * getShapeData(Shape shape) const;
 
 private:
+
     GeometryCache();
     virtual ~GeometryCache();
     void buildShapes();
 
     typedef QPair<int, int> IntPair;
     typedef QPair<unsigned int, unsigned int> VerticesIndices;
+    
+    
+    VShape _shapes;
 
     gpu::PipelinePointer _standardDrawPipeline;
     gpu::PipelinePointer _standardDrawPipelineNoBlend;

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -335,6 +335,8 @@ public:
 
     using VShape = std::array<ShapeData, NUM_SHAPES>;
 
+    /// returns ShapeData associated with the specified shape,
+    /// otherwise nullptr in the event of an error.
     const ShapeData * getShapeData(Shape shape) const;
 
 private:

--- a/libraries/shared/src/ShapeInfo.cpp
+++ b/libraries/shared/src/ShapeInfo.cpp
@@ -126,7 +126,7 @@ int ShapeInfo::getLargestSubshapePointCount() const {
 }
 
 float ShapeInfo::computeVolume() const {
-    //TODO WL21389: Add support for other ShapeTypes( CYLINDER_X, CYLINDER_Y, etc).
+    //TODO WL21389: Add support for other ShapeTypes( CYLINDER_X, CYLINDER_Z, etc).
     const float DEFAULT_VOLUME = 1.0f;
     float volume = DEFAULT_VOLUME;
     switch(_type) {

--- a/libraries/shared/src/ShapeInfo.cpp
+++ b/libraries/shared/src/ShapeInfo.cpp
@@ -45,6 +45,10 @@ void ShapeInfo::setParams(ShapeType type, const glm::vec3& halfExtents, QString 
                 _halfExtents = glm::vec3(radius);
             }
             break;
+        case SHAPE_TYPE_CIRCLE: {
+            _halfExtents = glm::vec3(_halfExtents.x, MIN_HALF_EXTENT, _halfExtents.z);
+        }
+        break;
         case SHAPE_TYPE_COMPOUND:
         case SHAPE_TYPE_STATIC_MESH:
             _url = QUrl(url);

--- a/libraries/shared/src/ShapeInfo.cpp
+++ b/libraries/shared/src/ShapeInfo.cpp
@@ -75,9 +75,7 @@ void ShapeInfo::setSphere(float radius) {
 }
 
 void ShapeInfo::setPointCollection(const ShapeInfo::PointCollection& pointCollection) {
-    //TODO WL21389: May need to skip resetting type here.
     _pointCollection = pointCollection;
-    _type = (_pointCollection.size() > 0) ? SHAPE_TYPE_COMPOUND : SHAPE_TYPE_NONE;
     _doubleHashKey.clear();
 }
 

--- a/libraries/shared/src/ShapeInfo.h
+++ b/libraries/shared/src/ShapeInfo.h
@@ -46,7 +46,8 @@ enum ShapeType {
     SHAPE_TYPE_SIMPLE_HULL,
     SHAPE_TYPE_SIMPLE_COMPOUND,
     SHAPE_TYPE_STATIC_MESH,
-    SHAPE_TYPE_ELLIPSOID
+    SHAPE_TYPE_ELLIPSOID,
+    SHAPE_TYPE_CIRCLE
 };
 
 class ShapeInfo {
@@ -66,7 +67,7 @@ public:
     void setCapsuleY(float radius, float halfHeight);
     void setOffset(const glm::vec3& offset);
 
-    int getType() const { return _type; }
+    ShapeType getType() const { return _type; }
 
     const glm::vec3& getHalfExtents() const { return _halfExtents; }
     const glm::vec3& getOffset() const { return _offset; }

--- a/tests/gpu-test/src/TestInstancedShapes.cpp
+++ b/tests/gpu-test/src/TestInstancedShapes.cpp
@@ -10,17 +10,17 @@
 
 gpu::Stream::FormatPointer& getInstancedSolidStreamFormat();
 
-static const size_t TYPE_COUNT = 4;
-static const size_t ITEM_COUNT = 50;
-static const float SHAPE_INTERVAL = (PI * 2.0f) / ITEM_COUNT;
-static const float ITEM_INTERVAL = SHAPE_INTERVAL / TYPE_COUNT;
-
-static GeometryCache::Shape SHAPE[TYPE_COUNT] = {
+static GeometryCache::Shape SHAPE[] = {
     GeometryCache::Icosahedron,
     GeometryCache::Cube,
     GeometryCache::Sphere,
     GeometryCache::Tetrahedron,
 };
+
+static const size_t TYPE_COUNT = (sizeof(SHAPE) / sizeof((SHAPE)[0]));
+static const size_t ITEM_COUNT = 50;
+static const float SHAPE_INTERVAL = (PI * 2.0f) / ITEM_COUNT;
+static const float ITEM_INTERVAL = SHAPE_INTERVAL / TYPE_COUNT;
 
 const gpu::Element POSITION_ELEMENT { gpu::VEC3, gpu::FLOAT, gpu::XYZ };
 const gpu::Element NORMAL_ELEMENT { gpu::VEC3, gpu::FLOAT, gpu::XYZ };
@@ -34,8 +34,13 @@ TestInstancedShapes::TestInstancedShapes() {
     static const float ITEM_RADIUS = 20;
     static const vec3 ITEM_TRANSLATION { 0, 0, -ITEM_RADIUS };
     for (size_t i = 0; i < TYPE_COUNT; ++i) {
-        GeometryCache::Shape shape = SHAPE[i];
-        GeometryCache::ShapeData shapeData = geometryCache->_shapes[shape];
+        //GeometryCache::Shape shape = SHAPE[i];
+        //const GeometryCache::ShapeData *shapeData = geometryCache->getShapeData( shape );
+        //if (!shapeData) {
+
+        //    //--EARLY ITERATION EXIT--( didn't have shape data yet )
+        //    continue;
+        //}
         //indirectCommand._count
         float startingInterval = ITEM_INTERVAL * i;
         std::vector<mat4> typeTransforms;
@@ -62,7 +67,12 @@ void TestInstancedShapes::renderTest(size_t testId, RenderArgs* args) {
     batch.setInputFormat(getInstancedSolidStreamFormat());
     for (size_t i = 0; i < TYPE_COUNT; ++i) {
         GeometryCache::Shape shape = SHAPE[i];
-        GeometryCache::ShapeData shapeData = geometryCache->_shapes[shape];
+        const GeometryCache::ShapeData *shapeData = geometryCache->getShapeData( shape );
+        if (!shapeData) {
+
+            //--EARLY ITERATION EXIT--( didn't have shape data yet )
+            continue;
+        }
         
         std::string namedCall = __FUNCTION__ + std::to_string(i);
 
@@ -71,13 +81,13 @@ void TestInstancedShapes::renderTest(size_t testId, RenderArgs* args) {
             batch.setModelTransform(transforms[i][j]);
             batch.setupNamedCalls(namedCall, [=](gpu::Batch& batch, gpu::Batch::NamedBatchData&) {
                 batch.setInputBuffer(gpu::Stream::COLOR, gpu::BufferView(colorBuffer, i * ITEM_COUNT * 4, colorBuffer->getSize(), COLOR_ELEMENT));
-                shapeData.drawInstances(batch, ITEM_COUNT);
+                shapeData->drawInstances(batch, ITEM_COUNT);
             });
         }
 
         //for (size_t j = 0; j < ITEM_COUNT; ++j) {
         //    batch.setModelTransform(transforms[j + i * ITEM_COUNT]);
-        //    shapeData.draw(batch);
+        //    shapeData->draw(batch);
         //}
     }
 }


### PR DESCRIPTION
*This is a preview of the changes that will be present within PR2 subsequent to PR1's merger.
** PR2 contains support for the polyhedrons and polygons sans Torus and Quad which aren't currently supported within GeometryCache.
** PR2 excludes support for Cylinder_X, Cylinder_Z, and asymmetrical cylinders.  These will be included in a different PR. 

Note:
PR2 branch is based on RELEASE-6940 as opposed to RELEASE-6902 of 21389 branch currently used for PR1; however, for the purposes of this preview, the base branch is a version of 21389 rebased on 6940.