### PR TITLE
[Case 6491] Preview PR 5 - Fixes degree skip during rotation

### DIFF
--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -284,7 +284,6 @@ SelectionDisplay = (function() {
     };
     var handleHoverAlpha = 1.0;
 
-    var rotateOverlayTargetSize = 10000; // really big target
     var innerSnapAngle = 22.5; // the angle which we snap to on the inner rotation tool
     var innerRadius;
     var outerRadius;
@@ -801,24 +800,6 @@ SelectionDisplay = (function() {
     });
 
 
-    var rotateOverlayTarget = Overlays.addOverlay("circle3d", {
-        position: {
-            x: 0,
-            y: 0,
-            z: 0
-        },
-        size: rotateOverlayTargetSize,
-        color: {
-            red: 0,
-            green: 0,
-            blue: 0
-        },
-        alpha: 0.0,
-        solid: true,
-        visible: false,
-        rotation: yawOverlayRotation,
-    });
-
     var rotateOverlayInner = Overlays.addOverlay("circle3d", {
         position: {
             x: 0,
@@ -975,7 +956,6 @@ SelectionDisplay = (function() {
         yawHandle,
         pitchHandle,
         rollHandle,
-        rotateOverlayTarget,
         rotateOverlayInner,
         rotateOverlayOuter,
         rotateOverlayCurrent,
@@ -1030,7 +1010,6 @@ SelectionDisplay = (function() {
     overlayNames[pitchHandle] = "pitchHandle";
     overlayNames[rollHandle] = "rollHandle";
 
-    overlayNames[rotateOverlayTarget] = "rotateOverlayTarget";
     overlayNames[rotateOverlayInner] = "rotateOverlayInner";
     overlayNames[rotateOverlayOuter] = "rotateOverlayOuter";
     overlayNames[rotateOverlayCurrent] = "rotateOverlayCurrent";
@@ -1468,9 +1447,6 @@ SelectionDisplay = (function() {
             translateHandlesVisible = false;
         }
 
-        Overlays.editOverlay(rotateOverlayTarget, {
-            visible: rotationOverlaysVisible
-        });
         Overlays.editOverlay(rotateZeroOverlay, {
             visible: rotationOverlaysVisible
         });
@@ -3652,12 +3628,6 @@ SelectionDisplay = (function() {
             innerRadius: 0.9,
         });
 
-        Overlays.editOverlay(rotateOverlayTarget, {
-            visible: true,
-            rotation: handleRotation,
-            position: rotCenter
-        });
-
         Overlays.editOverlay(rotationDegreesDisplay, {
             visible: true,
         });
@@ -4166,9 +4136,6 @@ SelectionDisplay = (function() {
             if(wantDebug){
                 print("    Triggering hide of RotateOverlays");
             }
-            Overlays.editOverlay(rotateOverlayTarget, {
-                visible: false
-            });
             Overlays.editOverlay(rotateOverlayInner, {
                 visible: false
             });

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -45,11 +45,12 @@ SelectionManager = (function() {
             return;
         }
 
+        var wantDebug = false;
         var messageParsed;
         try {
             messageParsed = JSON.parse(message);
         } catch (err) {
-            print("error -- entitySelectionTool got malformed message: " + message);
+            print("ERROR: entitySelectionTool.handleEntitySelectionToolUpdates - got malformed message: " + message);
         }
 
         // if (message === 'callUpdate') {
@@ -57,7 +58,9 @@ SelectionManager = (function() {
         // }
 
         if (messageParsed.method === "selectEntity") {
-            print("setting selection to " + messageParsed.entityID);
+            if (wantDebug) {
+                print("setting selection to " + messageParsed.entityID);
+            }
             that.setSelections([messageParsed.entityID]);
         }
     }
@@ -225,7 +228,7 @@ SelectionManager = (function() {
             try {
                 listeners[j](selectionUpdated === true);
             } catch (e) {
-                print("EntitySelectionTool got exception: " + JSON.stringify(e));
+                print("ERROR: entitySelectionTool.update got exception: " + JSON.stringify(e));
             }
         }
     };
@@ -1473,29 +1476,46 @@ SelectionDisplay = (function() {
 
     // FUNCTION: SET SPACE MODE
     that.setSpaceMode = function(newSpaceMode) {
-        print("======> SetSpaceMode called. ========");
+        var wantDebug = false;
+        if (wantDebug) {
+            print("======> SetSpaceMode called. ========");
+        }
+
         if (spaceMode != newSpaceMode) {
-            print("    Updating SpaceMode From: " + spaceMode + " To: " + newSpaceMode);
+            if (wantDebug){
+                print("    Updating SpaceMode From: " + spaceMode + " To: " + newSpaceMode);
+            }
             spaceMode = newSpaceMode;
             that.updateHandles();
-        } else {
-            print("    Can't update SpaceMode. CurrentMode: " + spaceMode + " DesiredMode: " + newSpaceMode);
+        } else if(wantDebug){
+            print("WARNING: entitySelectionTool.setSpaceMode - Can't update SpaceMode. CurrentMode: " + spaceMode + " DesiredMode: " + newSpaceMode);
         }
-        print("====== SetSpaceMode called. <========");
+        if(wantDebug) {
+            print("====== SetSpaceMode called. <========");
+        }
     };
 
     // FUNCTION: TOGGLE SPACE MODE
     that.toggleSpaceMode = function() {
-        print("========> ToggleSpaceMode called. =========");
+        var wantDebug = false;
+        if (wantDebug){
+            print("========> ToggleSpaceMode called. =========");
+        }
         if (spaceMode == SPACE_WORLD && SelectionManager.selections.length > 1) {
-            print("Local space editing is not available with multiple selections");
+            if (wantDebug){
+                print("Local space editing is not available with multiple selections");
+            }
             return;
         }
-        print( "PreToggle: " + spaceMode);
+        if(wantDebug) {
+            print( "PreToggle: " + spaceMode);
+        }
         spaceMode = spaceMode == SPACE_LOCAL ? SPACE_WORLD : SPACE_LOCAL;
-        print( "PostToggle: " + spaceMode);
         that.updateHandles();
-        print("======== ToggleSpaceMode called. <=========");
+        if (wantDebug){
+            print( "PostToggle: " + spaceMode);        
+            print("======== ToggleSpaceMode called. <=========");
+        }
     };
 
     // FUNCTION: UNSELECT ALL
@@ -1504,9 +1524,12 @@ SelectionDisplay = (function() {
 
     // FUNCTION: UPDATE HANDLES
     that.updateHandles = function() {
-        print( "======> Update Handles =======" );
-        print( "    Selections Count: " + SelectionManager.selections.length );
-        print( "    SpaceMode: " + spaceMode );
+        var wantDebug = false;
+        if(wantDebug){
+            print( "======> Update Handles =======" );
+            print( "    Selections Count: " + SelectionManager.selections.length );
+            print( "    SpaceMode: " + spaceMode );
+        }
         if (SelectionManager.selections.length === 0) {
             that.setOverlaysVisible(false);
             return;
@@ -2248,7 +2271,9 @@ SelectionDisplay = (function() {
             rotation: Quat.fromPitchYawRollDegrees(90, 0, 0),
         });
 
-        print( "====== Update Handles <=======" );
+        if(wantDebug){
+            print( "====== Update Handles <=======" );
+        }
 
     };
 
@@ -2523,7 +2548,7 @@ SelectionDisplay = (function() {
         mode: "TRANSLATE_UP_DOWN",
         onBegin: function(event, pickRay, pickResult) {
             upDownPickNormal = Quat.getForward(lastCameraOrientation);
-            // Remove y component so the y-axis lies along the plane we picking on - this will
+            // Remove y component so the y-axis lies along the plane we're picking on - this will
             // give movements that follow the mouse.
             upDownPickNormal.y = 0;
             lastXYPick = rayPlaneIntersection(pickRay, SelectionManager.worldPosition, upDownPickNormal);
@@ -3057,7 +3082,10 @@ SelectionDisplay = (function() {
     // FUNCTION: CUTOFF STRETCH FUNC
     function cutoffStretchFunc(vector, change) {
         vector = change;
-        Vec3.print("Radius stretch: ", vector);
+        var wantDebug = false;
+        if (wantDebug){
+            Vec3.print("Radius stretch: ", vector);
+        }
         var length = vector.x + vector.y + vector.z;
         var props = selectionManager.savedProperties[selectionManager.selections[0]];
 
@@ -3511,21 +3539,27 @@ SelectionDisplay = (function() {
 
     // FUNCTION: UPDATE ROTATION DEGREES OVERLAY
     function updateRotationDegreesOverlay(angleFromZero, handleRotation, centerPosition) {
-        print( "---> updateRotationDegreesOverlay ---" );
-        print("    AngleFromZero: " + angleFromZero );
-        print("    HandleRotation - X: " + handleRotation.x + " Y: " + handleRotation.y + " Z: " + handleRotation.z );
-        print("    CenterPos - " + centerPosition.x + " Y: " + centerPosition.y + " Z: " + centerPosition.z );
+        var wantDebug = false;
+        if(wantDebug){
+            print( "---> updateRotationDegreesOverlay ---" );
+            print("    AngleFromZero: " + angleFromZero );
+            print("    HandleRotation - X: " + handleRotation.x + " Y: " + handleRotation.y + " Z: " + handleRotation.z );
+            print("    CenterPos - " + centerPosition.x + " Y: " + centerPosition.y + " Z: " + centerPosition.z );
+        }
+
         var angle = angleFromZero * (Math.PI / 180);
         var position = {
             x: Math.cos(angle) * outerRadius * ROTATION_DISPLAY_DISTANCE_MULTIPLIER,
             y: Math.sin(angle) * outerRadius * ROTATION_DISPLAY_DISTANCE_MULTIPLIER,
             z: 0,
         };
-        print("    Angle: " + angle );
-        print("    InitialPos: " + position.x + ", " + position.y + ", " + position.z);
+        if(wantDebug){
+            print("    Angle: " + angle );
+            print("    InitialPos: " + position.x + ", " + position.y + ", " + position.z);
+        }
+        
         position = Vec3.multiplyQbyV(handleRotation, position);
         position = Vec3.sum(centerPosition, position);
-        print("    TranslatedPos: " + position.x + ", " + position.y + ", " + position.z);
         var overlayProps = {
             position: position,
             dimensions: {
@@ -3535,18 +3569,24 @@ SelectionDisplay = (function() {
             lineHeight: innerRadius * ROTATION_DISPLAY_LINE_HEIGHT_MULTIPLIER,
             text: normalizeDegrees(angleFromZero) + "°",
         };
-        print("    OverlayDim - X: " + overlayProps.dimensions.x + " Y: " + overlayProps.dimensions.y + " Z: " + overlayProps.dimensions.z );
-        print("    OverlayLineHeight: " + overlayProps.lineHeight );
-        print("    OverlayText: " + overlayProps.text );
+        if(wantDebug){
+            print("    TranslatedPos: " + position.x + ", " + position.y + ", " + position.z);
+            print("    OverlayDim - X: " + overlayProps.dimensions.x + " Y: " + overlayProps.dimensions.y + " Z: " + overlayProps.dimensions.z );
+            print("    OverlayLineHeight: " + overlayProps.lineHeight );
+            print("    OverlayText: " + overlayProps.text );
+        }
+
         Overlays.editOverlay(rotationDegreesDisplay, overlayProps);
-        print( "<--- updateRotationDegreesOverlay ---" );
+        if (wantDebug){
+            print( "<--- updateRotationDegreesOverlay ---" );
+        }
     }
 
     // FUNCTION DEF: updateSelectionsRotation
     //    Helper func used by rotation grabber tools 
     function updateSelectionsRotation( rotationChange ) {
         if ( ! rotationChange ) {
-            print("ERROR( updateSelectionsRotation ) - Invalid arg specified!!");
+            print("ERROR: entitySelectionTool.updateSelectionsRotation - Invalid arg specified!!");
 
             //--EARLY EXIT--
             return;
@@ -3649,7 +3689,7 @@ SelectionDisplay = (function() {
     function helperRotationHandleOnMove( event, rotAroundAxis, rotCenter, handleRotation ) {
 
         if ( ! rotZero ) {
-            print("ERROR( handleRotationHandleOnMove ) - Invalid RotationZero Specified (missed rotation target plane?)" );
+            print("ERROR: entitySelectionTool.handleRotationHandleOnMove - Invalid RotationZero Specified (missed rotation target plane?)" );
 
             //--EARLY EXIT--
             return;
@@ -3899,7 +3939,6 @@ SelectionDisplay = (function() {
             }
 
             entityIconOverlayManager.setIconsSelectable(selectionManager.selections, true);
-            //TODO_Case6491:  Merge if..else( selectionBox ) when onBegin of transXZ is normalized.
 
             var hitTool = grabberTools[ hitOverlayID ];
             if ( hitTool ) {

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -295,9 +295,6 @@ SelectionDisplay = (function() {
     var pitchCenter;
     var rollCenter;
     var rotZero;
-    var yawNormal;
-    var pitchNormal;
-    var rollNormal;
     var rotationNormal;
 
 
@@ -1089,12 +1086,8 @@ SelectionDisplay = (function() {
         return controllerComputePickRay() || Camera.computePickRay(x, y);
     }
     function addGrabberTool(overlay, tool) {
-        grabberTools[overlay] = {
-            mode: tool.mode,
-            onBegin: tool.onBegin,
-            onMove: tool.onMove,
-            onEnd: tool.onEnd,
-        };
+        grabberTools[overlay] = tool;
+        return tool;
     }
 
 
@@ -1224,22 +1217,6 @@ SelectionDisplay = (function() {
                     z: 0
                 });
 
-                yawNormal = {
-                    x: 0,
-                    y: 1,
-                    z: 0
-                };
-                pitchNormal = {
-                    x: 1,
-                    y: 0,
-                    z: 0
-                };
-                rollNormal = {
-                    x: 0,
-                    y: 0,
-                    z: 1
-                };
-
                 yawCorner = {
                     x: left + rotateHandleOffset,
                     y: bottom - rotateHandleOffset,
@@ -1300,23 +1277,6 @@ SelectionDisplay = (function() {
                     y: 0,
                     z: 90
                 });
-
-                yawNormal = {
-                    x: 0,
-                    y: 1,
-                    z: 0
-                };
-                pitchNormal = {
-                    x: 1,
-                    y: 0,
-                    z: 0
-                };
-                rollNormal = {
-                    x: 0,
-                    y: 0,
-                    z: 1
-                };
-
 
                 yawCorner = {
                     x: left + rotateHandleOffset,
@@ -1381,22 +1341,6 @@ SelectionDisplay = (function() {
                     z: 180
                 });
 
-                yawNormal = {
-                    x: 0,
-                    y: 1,
-                    z: 0
-                };
-                pitchNormal = {
-                    x: 1,
-                    y: 0,
-                    z: 0
-                };
-                rollNormal = {
-                    x: 0,
-                    y: 0,
-                    z: 1
-                };
-
                 yawCorner = {
                     x: right - rotateHandleOffset,
                     y: bottom - rotateHandleOffset,
@@ -1456,22 +1400,6 @@ SelectionDisplay = (function() {
                     z: 180
                 });
 
-                yawNormal = {
-                    x: 0,
-                    y: 1,
-                    z: 0
-                };
-                rollNormal = {
-                    x: 0,
-                    y: 0,
-                    z: 1
-                };
-                pitchNormal = {
-                    x: 1,
-                    y: 0,
-                    z: 0
-                };
-
                 yawCorner = {
                     x: right - rotateHandleOffset,
                     y: bottom - rotateHandleOffset,
@@ -1527,7 +1455,7 @@ SelectionDisplay = (function() {
             isPointLight = properties.type == "Light" && !properties.isSpotlight;
         }
 
-        if (mode == "ROTATE_YAW" || mode == "ROTATE_PITCH" || mode == "ROTATE_ROLL" || mode == "TRANSLATE_X in case they Z") {
+        if (mode == "ROTATE_YAW" || mode == "ROTATE_PITCH" || mode == "ROTATE_ROLL" || mode == "TRANSLATE_XZ") {
             rotationOverlaysVisible = true;
             rotateHandlesVisible = false;
             translateHandlesVisible = false;
@@ -2397,19 +2325,19 @@ SelectionDisplay = (function() {
     var duplicatedEntityIDs = null;
 
     // TOOL DEFINITION: TRANSLATE XZ TOOL
-    var translateXZTool = {
+    var translateXZTool = addGrabberTool(selectionBox,{
         mode: 'TRANSLATE_XZ',
         pickPlanePosition: { x: 0, y: 0, z: 0 },
         greatestDimension: 0.0,
         startingDistance: 0.0,
         startingElevation: 0.0,
-        onBegin: function(event,isAltFromGrab,intersectInfo) {
+        onBegin: function(event, pickRay, pickResult, doClone) {
             var wantDebug = false;
             if(wantDebug){
                 print("================== TRANSLATE_XZ(Beg) -> =======================");
-                Vec3.print("    intersectInfo.queryRay", intersectInfo.queryRay);
-                Vec3.print("    intersectInfo.queryRay.origin", intersectInfo.queryRay.origin);
-                Vec3.print("    intersectInfo.results.intersection", intersectInfo.results.intersection);
+                Vec3.print("    pickRay", pickRay);
+                Vec3.print("    pickRay.origin", pickRay.origin);
+                Vec3.print("    pickResult.intersection", pickResult.intersection);
             }
 
             SelectionManager.saveProperties();
@@ -2417,19 +2345,19 @@ SelectionDisplay = (function() {
             that.setGrabberMoveUpVisible( false );
 
             startPosition = SelectionManager.worldPosition;
-            mode = translateXZTool.mode;
+            mode = translateXZTool.mode; // Note this overrides mode = "CLONE"
 
-            translateXZTool.pickPlanePosition = intersectInfo.results.intersection;
+            translateXZTool.pickPlanePosition = pickResult.intersection;
             translateXZTool.greatestDimension = Math.max(Math.max(SelectionManager.worldDimensions.x, SelectionManager.worldDimensions.y), SelectionManager.worldDimensions.z);
-            translateXZTool.startingDistance = Vec3.distance(intersectInfo.queryRay.origin, SelectionManager.position);
-            translateXZTool.startingElevation = translateXZTool.elevation(intersectInfo.queryRay.origin, translateXZTool.pickPlanePosition);
+            translateXZTool.startingDistance = Vec3.distance(pickRay.origin, SelectionManager.position);
+            translateXZTool.startingElevation = translateXZTool.elevation(pickRay.origin, translateXZTool.pickPlanePosition);
             if (wantDebug) {
                 print("    longest dimension: " + translateXZTool.greatestDimension);
                 print("    starting distance: " + translateXZTool.startingDistance);
                 print("    starting elevation: " + translateXZTool.startingElevation);
             }
 
-            initialXZPick = rayPlaneIntersection(intersectInfo.queryRay, translateXZTool.pickPlanePosition, {
+            initialXZPick = rayPlaneIntersection(pickRay, translateXZTool.pickPlanePosition, {
                 x: 0,
                 y: 1,
                 z: 0
@@ -2438,7 +2366,7 @@ SelectionDisplay = (function() {
             // Duplicate entities if alt is pressed.  This will make a
             // copy of the selected entities and move the _original_ entities, not
             // the new ones.
-            if (event.isAlt || isAltFromGrab) {
+            if (event.isAlt || doClone) {
                 duplicatedEntityIDs = [];
                 for (var otherEntityID in SelectionManager.savedProperties) {
                     var properties = SelectionManager.savedProperties[otherEntityID];
@@ -2610,16 +2538,14 @@ SelectionDisplay = (function() {
 
             SelectionManager._update();
         }
-    };
-
+    });
+    
     // GRABBER TOOL: GRABBER MOVE UP
     var lastXYPick = null;
     var upDownPickNormal = null;
     addGrabberTool(grabberMoveUp, {
         mode: "TRANSLATE_UP_DOWN",
-        onBegin: function(event, intersectResult) {
-            pickRay = generalComputePickRay(event.x, event.y);
-
+        onBegin: function(event, pickRay, pickResult) {
             upDownPickNormal = Quat.getForward(lastCameraOrientation);
             // Remove y component so the y-axis lies along the plane we picking on - this will
             // give movements that follow the mouse.
@@ -2692,23 +2618,9 @@ SelectionDisplay = (function() {
     // GRABBER TOOL: GRABBER CLONER
     addGrabberTool(grabberCloner, {
         mode: "CLONE",
-        onBegin: function(event, intersectResult) {
-
-            var pickRay = generalComputePickRay(event.x, event.y);
-            //TODO_Case6491:  This may be doing duplicate works that's handled
-            //                within translateXZTool.onBegin.  Verify and if so
-            //                remove...
-            var result = Overlays.findRayIntersection(pickRay);
-            translateXZTool.pickPlanePosition = result.intersection;
-            translateXZTool.greatestDimension = Math.max(Math.max(SelectionManager.worldDimensions.x, SelectionManager.worldDimensions.y),
-                SelectionManager.worldDimensions.z);
-
-            var intersectInfo = {
-                queryRay: pickRay,
-                results: intersectResult
-            };
-
-            translateXZTool.onBegin(event,true,intersectInfo);
+        onBegin: function(event, pickRay, pickResult) {
+            var doClone = true;
+            translateXZTool.onBegin(event,pickRay,pickResult,doClone);
         },
         elevation: function (event) {
             translateXZTool.elevation(event);
@@ -2781,7 +2693,7 @@ SelectionDisplay = (function() {
         var pickRayPosition3D = null;
         var rotation = null;
 
-        var onBegin = function(event, intersectResult) {
+        var onBegin = function(event, pickRay, pickResult) {
             var properties = Entities.getEntityProperties(SelectionManager.selections[0]);
             initialProperties = properties;
             rotation = spaceMode == SPACE_LOCAL ? properties.rotation : Quat.fromPitchYawRollDegrees(0, 0, 0);
@@ -3163,7 +3075,7 @@ SelectionDisplay = (function() {
         }
         var tool = makeStretchTool(mode, direction, pivot, offset, handleMove);
 
-        addGrabberTool(overlay, tool);
+        return addGrabberTool(overlay, tool);
     }
 
     // FUNCTION: CUTOFF STRETCH FUNC
@@ -3686,7 +3598,7 @@ SelectionDisplay = (function() {
         }
     }
 
-    function helperRotationHandleOnBegin( event, rotNormal, rotCenter, handleRotation ) {
+    function helperRotationHandleOnBegin( event, pickRay, rotAroundAxis, rotCenter, handleRotation ) {
         var wantDebug = false;
         if (wantDebug) {
             print("================== " + mode + "(rotation helper onBegin) -> =======================");
@@ -3698,7 +3610,8 @@ SelectionDisplay = (function() {
         that.setGrabberMoveUpVisible( false );
 
         initialPosition = SelectionManager.worldPosition;
-        rotationNormal = rotNormal;
+        rotationNormal = { x: 0, y: 0, z: 0 };
+        rotationNormal[rotAroundAxis] = 1;
 
         // Size the overlays to the current selection size
         var diagonal = (Vec3.length(selectionManager.worldDimensions) / 2) * 1.1;
@@ -3751,11 +3664,11 @@ SelectionDisplay = (function() {
 
         updateRotationDegreesOverlay(0, handleRotation, rotCenter);
         
-        // Compute zero position now that the overlay is set up.
-        // TODO editOverlays sync
-        var pickRay = generalComputePickRay(event.x, event.y);
-        
+        // editOverlays may not have committed rotation changes.
+        // Compute zero position based on where the overlay will be eventually.
         var result = rayPlaneIntersection( pickRay, rotCenter, rotationNormal );
+        // In case of a parallel ray, this will be null, which will cause early-out
+        // in the onMove helper.
         rotZero = result;
         
         if (wantDebug) {
@@ -3772,7 +3685,7 @@ SelectionDisplay = (function() {
             return;
         }
 
-        var wantDebug = true;
+        var wantDebug = false;
         if (wantDebug) {
             print("================== "+ mode + "(rotation helper onMove) -> =======================");
             Vec3.print("    rotZero: ", rotZero);
@@ -3785,15 +3698,15 @@ SelectionDisplay = (function() {
             visible: false
         });
 
-        var result = Overlays.findRayIntersection(pickRay, true, [rotateOverlayTarget]);
-        if (result.intersects) {
+        var result = rayPlaneIntersection( pickRay, rotCenter, rotationNormal );
+        if (result) {
             var centerToZero = Vec3.subtract(rotZero, rotCenter);
-            var centerToIntersect = Vec3.subtract(result.intersection, rotCenter);
+            var centerToIntersect = Vec3.subtract(result, rotCenter);
             if (wantDebug) {
                 Vec3.print("    RotationNormal:    ", rotationNormal);
                 Vec3.print("    rotZero:           ", rotZero);
                 Vec3.print("    rotCenter:         ", rotCenter);
-                Vec3.print("    intersect:         ", result.intersection);
+                Vec3.print("    intersect:         ", result);
                 Vec3.print("    centerToZero:      ", centerToZero);
                 Vec3.print("    centerToIntersect: ", centerToIntersect);
             }
@@ -3801,7 +3714,7 @@ SelectionDisplay = (function() {
             //             handles that internally, so it's to pass unnormalized vectors here.
             var angleFromZero = Vec3.orientedAngle(centerToZero, centerToIntersect, rotationNormal);
 
-            var distanceFromCenter = Vec3.distance(rotCenter, result.intersection);
+            var distanceFromCenter = Vec3.length(centerToIntersect);
             var snapToInner = distanceFromCenter < innerRadius;
             var snapAngle = snapToInner ? innerSnapAngle : 1.0;
             angleFromZero = Math.floor(angleFromZero / snapAngle) * snapAngle;
@@ -3898,9 +3811,8 @@ SelectionDisplay = (function() {
     var initialPosition = SelectionManager.worldPosition;
     addGrabberTool(yawHandle, {
         mode: "ROTATE_YAW",
-        onBegin: function(event, intersectResult) {
-            mode = "ROTATE_YAW";
-            helperRotationHandleOnBegin( event, yawNormal, yawCenter, yawHandleRotation );
+        onBegin: function(event, pickRay, pickResult) {
+            helperRotationHandleOnBegin( event, pickRay, "y", yawCenter, yawHandleRotation );
         },
         onEnd: function(event, reason) {
             helperRotationHandleOnEnd();
@@ -3914,9 +3826,8 @@ SelectionDisplay = (function() {
     // PITCH GRABBER TOOL DEFINITION
     addGrabberTool(pitchHandle, {
         mode: "ROTATE_PITCH",
-        onBegin: function (event, intersectResult) {
-            mode = "ROTATE_PITCH";
-            helperRotationHandleOnBegin( event, pitchNormal, pitchCenter, pitchHandleRotation );
+        onBegin: function(event, pickRay, pickResult) {
+            helperRotationHandleOnBegin( event, pickRay, "x", pitchCenter, pitchHandleRotation );
         },
         onEnd: function(event, reason) {
             helperRotationHandleOnEnd();
@@ -3930,9 +3841,8 @@ SelectionDisplay = (function() {
     // ROLL GRABBER TOOL DEFINITION
     addGrabberTool(rollHandle, {
         mode: "ROTATE_ROLL",
-        onBegin: function (event, intersectResult) {
-            mode = "ROTATE_ROLL";
-            helperRotationHandleOnBegin( event, rollNormal, rollCenter, rollHandleRotation );
+        onBegin: function(event, pickRay, pickResult) {
+            helperRotationHandleOnBegin( event, pickRay, "z", rollCenter, rollHandleRotation );
         },
         onEnd: function (event, reason) {
             helperRotationHandleOnEnd();
@@ -4007,7 +3917,9 @@ SelectionDisplay = (function() {
             }
         }
 
+        // Start with unknown mode, in case no tool can handle this.
         mode = "UNKNOWN";
+
         var results = testRayIntersect( pickRay, interactiveOverlays );
         if ( results.intersects ){
             var hitOverlayID = results.overlayID;
@@ -4018,32 +3930,19 @@ SelectionDisplay = (function() {
 
             entityIconOverlayManager.setIconsSelectable(selectionManager.selections, true);
             //TODO_Case6491:  Merge if..else( selectionBox ) when onBegin of transXZ is normalized.
-            if ( hitOverlayID == selectionBox ) {
 
-                activeTool = translateXZTool;
-                if(wantDebug){
-                    print("    Clicked selectionBox, Activating Tool: " + activeTool.mode );
-                }
-                var intersectInfo = {
-                    queryRay: pickRay,
-                    results: results
-                };
-
-                activeTool.onBegin(event, null, intersectInfo);
-            } else { //...see if a tool was hit as that's the only thing left that we care about.
-                var hitTool = grabberTools[ hitOverlayID ];
-                if ( hitTool ) {
-                    activeTool = hitTool;
-                    mode = activeTool.mode; //< TODO: Is this centrally handled in all tool begins?
-                    if (activeTool.onBegin) {
-                        activeTool.onBegin(event, results);
-                    } else {
-                        print("ERROR: entitySelectionTool.mousePressEvent - ActiveTool( " + activeTool.mode + " ) missing onBegin");
-                    }
+            var hitTool = grabberTools[ hitOverlayID ];
+            if ( hitTool ) {
+                activeTool = hitTool;
+                mode = activeTool.mode;
+                if (activeTool.onBegin) {
+                    activeTool.onBegin(event, pickRay, results);
                 } else {
-                    print("ERROR: entitySelectionTool.mousePressEvent - Hit unexpected object, check interactiveOverlays");
-                }//--End_if( hitTool )
-            }//--End_if( hitOverlayID == selectionBox )
+                    print("ERROR: entitySelectionTool.mousePressEvent - ActiveTool( " + activeTool.mode + " ) missing onBegin");
+                }
+            } else {
+                print("ERROR: entitySelectionTool.mousePressEvent - Hit unexpected object, check interactiveOverlays");
+            }//--End_if( hitTool )
         }//--End_If( results.intersects )
 
         if (wantDebug) {

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -294,9 +294,7 @@ SelectionDisplay = (function() {
     var yawCenter;
     var pitchCenter;
     var rollCenter;
-    var yawZero;
-    var pitchZero;
-    var rollZero;
+    var rotZero;
     var yawNormal;
     var pitchNormal;
     var rollNormal;
@@ -3688,10 +3686,10 @@ SelectionDisplay = (function() {
         }
     }
 
-    function helperRotationHandleOnBegin( rotMode, rotNormal, rotCenter, handleRotation ) {
+    function helperRotationHandleOnBegin( event, rotNormal, rotCenter, handleRotation ) {
         var wantDebug = false;
         if (wantDebug) {
-            print("================== " + rotMode + "(onBegin) -> =======================");
+            print("================== " + mode + "(rotation helper onBegin) -> =======================");
         }
 
         SelectionManager.saveProperties();
@@ -3700,7 +3698,6 @@ SelectionDisplay = (function() {
         that.setGrabberMoveUpVisible( false );
 
         initialPosition = SelectionManager.worldPosition;
-        mode = rotMode;
         rotationNormal = rotNormal;
 
         // Size the overlays to the current selection size
@@ -3753,28 +3750,31 @@ SelectionDisplay = (function() {
         });
 
         updateRotationDegreesOverlay(0, handleRotation, rotCenter);
+        
+        // Compute zero position now that the overlay is set up.
+        // TODO editOverlays sync
+        var pickRay = generalComputePickRay(event.x, event.y);
+        
+        var result = rayPlaneIntersection( pickRay, rotCenter, rotationNormal );
+        rotZero = result;
+        
         if (wantDebug) {
-            print("================== " + rotMode + "(onBegin) <- =======================");
+            print("================== " + mode + "(rotation helper onBegin) <- =======================");
         }
     }//--End_Function( helperRotationHandleOnBegin )
 
-    function helperRotationHandleOnMove( event, rotMode, rotZero, rotCenter, handleRotation ) {
+    function helperRotationHandleOnMove( event, rotAroundAxis, rotCenter, handleRotation ) {
 
-        if ( ! (rotMode == "ROTATE_YAW" || rotMode == "ROTATE_PITCH" || rotMode == "ROTATE_ROLL") ) {
-            print("ERROR( handleRotationHandleOnMove ) - Encountered Unknown/Invalid RotationMode: " + rotMode );
-
-            //--EARLY EXIT--
-            return;
-        } else if ( ! rotZero ) {
-            print("ERROR( handleRotationHandleOnMove ) - Invalid RotationZero Specified" );
+        if ( ! rotZero ) {
+            print("ERROR( handleRotationHandleOnMove ) - Invalid RotationZero Specified (missed rotation target plane?)" );
 
             //--EARLY EXIT--
             return;
         }
 
-        var wantDebug = false;
+        var wantDebug = true;
         if (wantDebug) {
-            print("================== "+ rotMode + "(onMove) -> =======================");
+            print("================== "+ mode + "(rotation helper onMove) -> =======================");
             Vec3.print("    rotZero: ", rotZero);
         }
         var pickRay = generalComputePickRay(event.x, event.y);
@@ -3790,7 +3790,12 @@ SelectionDisplay = (function() {
             var centerToZero = Vec3.subtract(rotZero, rotCenter);
             var centerToIntersect = Vec3.subtract(result.intersection, rotCenter);
             if (wantDebug) {
-                Vec3.print("    RotationNormal: ", rotationNormal);
+                Vec3.print("    RotationNormal:    ", rotationNormal);
+                Vec3.print("    rotZero:           ", rotZero);
+                Vec3.print("    rotCenter:         ", rotCenter);
+                Vec3.print("    intersect:         ", result.intersection);
+                Vec3.print("    centerToZero:      ", centerToZero);
+                Vec3.print("    centerToIntersect: ", centerToIntersect);
             }
             // Note: orientedAngle which wants normalized centerToZero and centerToIntersect
             //             handles that internally, so it's to pass unnormalized vectors here.
@@ -3801,18 +3806,9 @@ SelectionDisplay = (function() {
             var snapAngle = snapToInner ? innerSnapAngle : 1.0;
             angleFromZero = Math.floor(angleFromZero / snapAngle) * snapAngle;
 
-            var rotChange = null;
-            switch( rotMode ) {
-                case "ROTATE_YAW":
-                    rotChange = Quat.fromVec3Degrees( {x: 0, y: angleFromZero, z: 0} );
-                break;
-                case "ROTATE_PITCH":
-                    rotChange = Quat.fromVec3Degrees( {x: angleFromZero, y: 0, z: 0} );
-                break;
-                case "ROTATE_ROLL":
-                    rotChange = Quat.fromVec3Degrees( {x: 0, y: 0, z: angleFromZero} );
-                break;
-            }
+            var vec3Degrees = { x: 0, y: 0, z: 0 };
+            vec3Degrees[rotAroundAxis] = angleFromZero;
+            var rotChange = Quat.fromVec3Degrees( vec3Degrees );
             updateSelectionsRotation( rotChange );
 
             updateRotationDegreesOverlay(angleFromZero, handleRotation, rotCenter);
@@ -3868,7 +3864,7 @@ SelectionDisplay = (function() {
         }//--End_If( results.intersects )
 
         if (wantDebug) {
-            print("================== "+ rotMode + "(onMove) <- =======================");
+            print("================== "+ mode + "(rotation helper onMove) <- =======================");
         }
     }//--End_Function( helperRotationHandleOnMove )
 
@@ -3903,17 +3899,14 @@ SelectionDisplay = (function() {
     addGrabberTool(yawHandle, {
         mode: "ROTATE_YAW",
         onBegin: function(event, intersectResult) {
-            //note: It's expected that the intersect result is passed when this is called.
-            //      validity will be checked later as a pre-requisite for onMove handling.
-            yawZero = intersectResult.intersection;
-
-            helperRotationHandleOnBegin( "ROTATE_YAW", yawNormal, yawCenter, yawHandleRotation );
+            mode = "ROTATE_YAW";
+            helperRotationHandleOnBegin( event, yawNormal, yawCenter, yawHandleRotation );
         },
         onEnd: function(event, reason) {
             helperRotationHandleOnEnd();
         },
         onMove: function(event) {
-            helperRotationHandleOnMove( event, "ROTATE_YAW", yawZero, yawCenter, yawHandleRotation );
+            helperRotationHandleOnMove( event, "y", yawCenter, yawHandleRotation );
         }
     });
 
@@ -3922,17 +3915,14 @@ SelectionDisplay = (function() {
     addGrabberTool(pitchHandle, {
         mode: "ROTATE_PITCH",
         onBegin: function (event, intersectResult) {
-            //note: It's expected that the intersect result is passed when this is called.
-            //      validity will be checked later as a pre-requisite for onMove handling.
-            pitchZero = intersectResult.intersection;
-
-            helperRotationHandleOnBegin( "ROTATE_PITCH", pitchNormal, pitchCenter, pitchHandleRotation );
+            mode = "ROTATE_PITCH";
+            helperRotationHandleOnBegin( event, pitchNormal, pitchCenter, pitchHandleRotation );
         },
         onEnd: function(event, reason) {
             helperRotationHandleOnEnd();
         },
         onMove: function (event) {
-            helperRotationHandleOnMove( event, "ROTATE_PITCH", pitchZero, pitchCenter, pitchHandleRotation );
+            helperRotationHandleOnMove( event, "x", pitchCenter, pitchHandleRotation );
         }
     });
 
@@ -3941,17 +3931,14 @@ SelectionDisplay = (function() {
     addGrabberTool(rollHandle, {
         mode: "ROTATE_ROLL",
         onBegin: function (event, intersectResult) {
-            //note: It's expected that the intersect result is passed when this is called.
-            //      validity will be checked later as a pre-requisite for onMove handling.
-            rollZero = intersectResult.intersection;
-
-            helperRotationHandleOnBegin( "ROTATE_ROLL", rollNormal, rollCenter, rollHandleRotation );
+            mode = "ROTATE_ROLL";
+            helperRotationHandleOnBegin( event, rollNormal, rollCenter, rollHandleRotation );
         },
         onEnd: function (event, reason) {
             helperRotationHandleOnEnd();
         },
         onMove: function(event) {
-            helperRotationHandleOnMove( event, "ROTATE_ROLL", rollZero, rollCenter, rollHandleRotation );
+            helperRotationHandleOnMove( event, "z", rollCenter, rollHandleRotation );
         }
     });
 


### PR DESCRIPTION
This Preview PR is based on Case 6491's Preview PR 4 which has changes to mousePressEvent selection flow. The overall PR is broken into preview chunks to allow for review in smaller logical pieces.

Description:
Previously, when rotating, it would be easy to achieve 1 degree granularity, except near the 0 degree and 180 degree "poles", where it would often e.g. jump from 10 to -10, or 174 to -175, or similar.

yawZero/pitchZero/rollZero were all based on the yawHandle/pitchHandle/rollHandle ray intersection, and were not necessarily coplanar with rotateOverlayTarget. As a result, centerToZero didn't lie on the expected plane, while centerToIntersect did.  This had the effect of distorting the rotation range.

We also have a possible issue in here with editOverlay(rotationOverlayTarget,{rotation:...}) not taking effect immediately.  Better to take the existing ray and cast against a known plane, as e.g. translateXZTool and such do.  No risk of stale rotation in that case.

This also cleans up rotationHelper args a bit to avoid some string switches and keep flow a little more readable.

This PR also has a logging/error message normalization pass.